### PR TITLE
Use official style-loader again

### DIFF
--- a/config/webpack/webpack-client.config.js
+++ b/config/webpack/webpack-client.config.js
@@ -100,7 +100,7 @@ module.exports = (options) => {
                         fallback: {
                             loader: 'style-loader',
                             options: {
-                                fixUrls: !options.build,
+                                convertToAbsoluteUrls: !options.build,
                             },
                         },
                         use: [

--- a/config/webpack/webpack-server.config.js
+++ b/config/webpack/webpack-server.config.js
@@ -95,7 +95,7 @@ module.exports = (options) => {
                             fallback: {
                                 loader: 'style-loader',
                                 options: {
-                                    fixUrls: options.env === 'dev',
+                                    convertToAbsoluteUrls: true,
                                 },
                             },
                             use: [

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "react-hot-loader": "^3.0.0-beta.6",
     "rimraf": "^2.5.4",
     "skip-loader": "^1.0.0",
-    "style-loader": "git://github.com/bendytree/style-loader.git#4f9f4494184f3b8a427a381249eb0e09f3787768",
+    "style-loader": "^0.16.0",
     "stylelint": "^7.9.0",
     "stylelint-config-moxy": "^2.0.0",
     "svg-css-modules-loader": "^1.3.0",


### PR DESCRIPTION
The official style-loader has fixed the issue with images + source maps, through a `convertAbsoluteUrls` option, see: https://github.com/webpack-contrib/style-loader/tree/5f56f9fd56aab7965d4eba28019d6e6079f5d610#converttoabsoluteurls

Fixes #9 