### PR TITLE
chore: Replace soon to be deprecated helmet's rewind() method with renderStatic

### DIFF
--- a/src/server-renderer.js
+++ b/src/server-renderer.js
@@ -39,7 +39,7 @@ export default async function render({ req, res, buildManifest }) {
 
     // Render document
     const html = renderDocument({
-        head: Helmet.rewind(),
+        helmet: Helmet.renderStatic(),
         rootHtml,
         config,
         buildManifest,
@@ -74,7 +74,7 @@ export async function renderError({ err, req, res, buildManifest }) {
 
     // Render document
     const html = renderDocument({
-        head: Helmet.rewind(),
+        helmet: Helmet.renderStatic(),
         rootHtml,
         config,
         buildManifest,

--- a/web/.index.html.js
+++ b/web/.index.html.js
@@ -1,6 +1,6 @@
 import difference from 'lodash/difference';
 
-export default function index({ head, rootHtml, config, buildManifest }) {
+export default function index({ helmet, rootHtml, config, buildManifest }) {
     const { assets, routes: { sync: syncRoutes, async: asyncRoutes } } = buildManifest;
     const { routesToPrefetch } = config;
 
@@ -16,15 +16,15 @@ export default function index({ head, rootHtml, config, buildManifest }) {
 
     return `
         <!DOCTYPE html>
-        <html ${head.htmlAttributes.toString()}>
+        <html ${helmet.htmlAttributes.toString()}>
             <head>
                 <meta charset="utf-8">
                 <meta http-equiv="x-ua-compatible" content="ie=edge">
                 <meta id="viewport" name="viewport" content="width=device-width, initial-scale=1" />
 
-                ${head.title.toString()}
-                ${head.meta.toString()}
-                ${head.link.toString()}
+                ${helmet.title.toString()}
+                ${helmet.meta.toString()}
+                ${helmet.link.toString()}
 
                 <!-- Roboto from Google-->
                 <link href="https://fonts.googleapis.com/css?family=Roboto:400,500,700" rel="stylesheet">


### PR DESCRIPTION
The `rewind` method will be deprecated according to the [docs](https://github.com/nfl/react-helmet#server-usage). 

Also, I think `helmet` is a better var name since it carries more than just info for the `<head>` tag.