### PR TITLE
fix: fix not being able to use react-hot-loader in IE11

### DIFF
--- a/scripts/config/webpack/config-client.js
+++ b/scripts/config/webpack/config-client.js
@@ -31,6 +31,7 @@ module.exports = ({ minify } = {}) => {
             main: [
                 require.resolve('dom4'), // Adds dom4 polyfills, such as Element.remove(), etc
                 isDev && require.resolve('eventsource-polyfill'), // Necessary to make hmr work on IE
+                isDev && require.resolve('core-js/modules/es6.symbol'), // Necessary to get around an issue with `react-hot-loader` requiring react, see: https://github.com/facebook/react/issues/8379#issuecomment-309916013
                 isDev && require.resolve('react-hot-loader/patch'), // For hot module reload
                 isDev && `${require.resolve('webpack-hot-middleware/client')}?reload=true`, // For hot module reload
                 require.resolve('svgxuse'), // Necessary because external svgs need a polyfill in IE


### PR DESCRIPTION
<img width="893" alt="screen shot 2017-12-20 at 13 04 33" src="https://user-images.githubusercontent.com/1017236/34208472-5cfd4f7e-e586-11e7-9744-2d0afaec74bd.png">

See: https://github.com/facebook/react/issues/8379#issuecomment-309916013
