### PR TITLE
fix: add fallback empty object if res.locals.isomorphic does not exist

### DIFF
--- a/scripts/middlewares/render.js
+++ b/scripts/middlewares/render.js
@@ -32,7 +32,7 @@ function renderError() {
             return next(err);
         }
 
-        const { exports, buildManifest } = res.locals.isomorphic;
+        const { exports, buildManifest } = res.locals.isomorphic || {};
 
         // Skip if there's no defined `renderError`
         if (!exports || !exports.renderError) {


### PR DESCRIPTION
The render error middlewares was breaking when no `res.locals.isomorphic` was defined. This PR adds an empty object fallback.