### PR TITLE
fix: remove hot-update files from memory

### DIFF
--- a/scripts/config/webpack/config-client.js
+++ b/scripts/config/webpack/config-client.js
@@ -45,6 +45,8 @@ module.exports = ({ minify } = {}) => {
             publicPath: `${publicUrl}/build/`,
             filename: isDev ? 'js/[name].js' : 'js/[name].[chunkhash].js',
             chunkFilename: isDev ? 'js/chunk.[name].js' : 'js/chunk.[name].[chunkhash].js',
+            hotUpdateChunkFilename: '[id].hot-update.js',
+            hotUpdateMainFilename: 'hot-update.json',
         },
         resolve: {
             alias: {


### PR DESCRIPTION
This prevents excess HMR files from being stored in memory which lead to excessive memory consumption after a period of time.

https://github.com/webpack/webpack/issues/1914