### PR TITLE
chore: disable module concatenation plugin

### DIFF
--- a/scripts/config/webpack/config-client.js
+++ b/scripts/config/webpack/config-client.js
@@ -215,8 +215,8 @@ module.exports = ({ minify } = {}) => {
             }),
             // Enabling gives us better debugging output
             new NamedModulesPlugin(),
-            // Enable scope hoisting which reduces bundle size
-            new ModuleConcatenationPlugin(),
+            // Enable scope hoisting which reduces bundle size, disable in development to increase (re)build performance
+            !isDev && new ModuleConcatenationPlugin(),
             // Ensures that hot reloading works
             isDev && new HotModuleReplacementPlugin(),
             // Alleviate cases where developers working on OSX, which does not follow strict path case sensitivity


### PR DESCRIPTION
Disabling this plugin resulted in an increased performance when rebuilding the project.

Active in production.

https://github.com/gaearon/react-hot-loader/issues/456