### PR TITLE
fix: targets on config client

### DIFF
--- a/scripts/config/webpack/config-client.js
+++ b/scripts/config/webpack/config-client.js
@@ -70,7 +70,7 @@ module.exports = ({ minify } = {}) => {
                                 cacheDirectory: true,
                                 presets: [
                                     [require.resolve('babel-preset-moxy'), {
-                                        targets: ['browser'],
+                                        targets: ['browsers'],
                                         react: true,
                                         modules: false,
                                     }],


### PR DESCRIPTION
`targets` should be 'browsers', according to our `babel-preset-moxy`.