### PR TITLE
chore: use hashed module ids plugin for production

### DIFF
--- a/scripts/config/webpack/config-client.js
+++ b/scripts/config/webpack/config-client.js
@@ -8,6 +8,7 @@ const { getEnvVariables, inlineEnvVariables } = require('./util/env');
 // Webpack plugins
 const SvgStorePlugin = require('external-svg-sprite-loader/lib/SvgStorePlugin');
 const NamedModulesPlugin = require('webpack/lib/NamedModulesPlugin');
+const HashedModuleIdsPlugin = require('webpack/lib/HashedModuleIdsPlugin');
 const LoaderOptionsPlugin = require('webpack/lib/LoaderOptionsPlugin');
 const HotModuleReplacementPlugin = require('webpack/lib/HotModuleReplacementPlugin');
 const NoEmitOnErrorsPlugin = require('webpack/lib/NoEmitOnErrorsPlugin');
@@ -216,8 +217,10 @@ module.exports = ({ minify } = {}) => {
                 ...inlineEnvVariables(envVars, { includeProcessEnv: true }),
                 'typeof window': '"object"',
             }),
-            // Enabling gives us better debugging output
-            new NamedModulesPlugin(),
+            // Enabling gives us better debugging output for development
+            isDev && new NamedModulesPlugin(),
+            // In production, ofuscate paths to modules
+            !isDev && new HashedModuleIdsPlugin(),
             // Enable scope hoisting which reduces bundle size, disable in development to increase (re)build performance
             !isDev && new ModuleConcatenationPlugin(),
             // Ensures that hot reloading works

--- a/scripts/config/webpack/config-server.js
+++ b/scripts/config/webpack/config-server.js
@@ -10,6 +10,7 @@ const { getEnvVariables, inlineEnvVariables } = require('./util/env');
 const UglifyJsPlugin = require('uglifyjs-webpack-plugin');
 const SvgStorePlugin = require('external-svg-sprite-loader/lib/SvgStorePlugin');
 const NamedModulesPlugin = require('webpack/lib/NamedModulesPlugin');
+const HashedModuleIdsPlugin = require('webpack/lib/HashedModuleIdsPlugin');
 const LoaderOptionsPlugin = require('webpack/lib/LoaderOptionsPlugin');
 const NoEmitOnErrorsPlugin = require('webpack/lib/NoEmitOnErrorsPlugin');
 const DefinePlugin = require('webpack/lib/DefinePlugin');
@@ -211,7 +212,9 @@ module.exports = ({ minify } = {}) => {
                 'typeof window': '"undefined"',
             }),
             // Add module names to factory functions so they appear in browser profiler
-            new NamedModulesPlugin(),
+            isDev && new NamedModulesPlugin(),
+            // In production, ofuscate paths to modules
+            !isDev && new HashedModuleIdsPlugin(),
             // Enable scope hoisting which reduces bundle size
             new ModuleConcatenationPlugin(),
             // Alleviate cases where developers working on OSX, which does not follow strict path case sensitivity


### PR DESCRIPTION
Fixes #35.

Do you have a preference regarding options for the plugin (`hashFunction `, `hashDigest `, `hashDigestLength `)?