### PR TITLE
feat: leverage etag validation to cache responses

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules
 npm-debug.log
 /public/build
+/public/_build
 /coverage
 .env

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ When the installation ends, copy [.env.sample ](./.env.sample) to `.env`. All th
 $ npm run build
 ```
 
-Builds the project for production, producing the bundled assets at `public/build`.
+Builds the project for production, producing the bundled assets at `public/_build`.
 Please run `npm run build -- -h` for more options.
 
 ### start

--- a/package-lock.json
+++ b/package-lock.json
@@ -4216,6 +4216,15 @@
       "integrity": "sha1-GzN5LhHpFKL9bW7WRHRkRE5fpkA=",
       "dev": true
     },
+    "d": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
+      "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
+      "dev": true,
+      "requires": {
+        "es5-ext": "^0.10.9"
+      }
+    },
     "dargs": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/dargs/-/dargs-4.1.0.tgz",
@@ -4944,6 +4953,38 @@
         "is-callable": "^1.1.1",
         "is-date-object": "^1.0.1",
         "is-symbol": "^1.0.1"
+      }
+    },
+    "es5-ext": {
+      "version": "0.10.42",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.42.tgz",
+      "integrity": "sha512-AJxO1rmPe1bDEfSR6TJ/FgMFYuTBhR5R57KW58iCkYACMyFbrkqVyzXSurYoScDGvgyMpk7uRF/lPUPPTmsRSA==",
+      "dev": true,
+      "requires": {
+        "es6-iterator": "~2.0.3",
+        "es6-symbol": "~3.1.1",
+        "next-tick": "1"
+      }
+    },
+    "es6-iterator": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
+      "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
+      "dev": true,
+      "requires": {
+        "d": "1",
+        "es5-ext": "^0.10.35",
+        "es6-symbol": "^3.1.1"
+      }
+    },
+    "es6-symbol": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
+      "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
+      "dev": true,
+      "requires": {
+        "d": "1",
+        "es5-ext": "~0.10.14"
       }
     },
     "escape-html": {
@@ -9988,6 +10029,12 @@
       "integrity": "sha1-brGa5aHuHdnfC5aeZs4Lf6MLXmA=",
       "dev": true
     },
+    "lodash.omitby": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.omitby/-/lodash.omitby-4.6.0.tgz",
+      "integrity": "sha1-XBX/R1StVVAWtTwEExHo8HkgR5E=",
+      "dev": true
+    },
     "lodash.padend": {
       "version": "4.6.1",
       "resolved": "https://registry.npmjs.org/lodash.padend/-/lodash.padend-4.6.1.tgz",
@@ -10091,10 +10138,14 @@
       }
     },
     "loglevelnext": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/loglevelnext/-/loglevelnext-1.0.4.tgz",
-      "integrity": "sha512-V3N6LAJAiGwa/zjtvmgs2tyeiCJ23bGNhxXN8R+v7k6TNlSlTz40mIyZYdmO762eBnEFymn0Mhha+WuAhnwMBg==",
-      "dev": true
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/loglevelnext/-/loglevelnext-1.0.5.tgz",
+      "integrity": "sha512-V/73qkPuJmx4BcBF19xPBr+0ZRVBhc4POxvZTZdMeXpJ4NItXSJ/MSwuFT0kQJlCbXvdlZoQQ/418bS1y9Jh6A==",
+      "dev": true,
+      "requires": {
+        "es6-symbol": "^3.1.1",
+        "object.assign": "^4.1.0"
+      }
     },
     "longest": {
       "version": "1.0.1",
@@ -10857,6 +10908,12 @@
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.5.1.tgz",
       "integrity": "sha512-3KL3fvuRkZ7s4IFOMfztb7zJp3QaVWnBeGoJlgB38XnCRPj/0tLzzLG5IB8NYOHbJ8g8UGrgZv44GLDk6CxTxA==",
+      "dev": true
+    },
+    "next-tick": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
+      "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw=",
       "dev": true
     },
     "nice-try": {
@@ -18586,9 +18643,9 @@
       }
     },
     "webpack-dev-middleware": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-3.1.2.tgz",
-      "integrity": "sha512-Z11Zp3GTvCe6mGbbtma+lMB9xRfJcNtupXfmvFBujyXqLNms6onDnSi9f/Cb2rw6KkD5kgibOfxhN7npZwTiGA==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-3.1.3.tgz",
+      "integrity": "sha512-I6Mmy/QjWU/kXwCSFGaiOoL5YEQIVmbb0o45xMoCyQAg/mClqZVTcsX327sPfekDyJWpCxb+04whNyLOIxpJdQ==",
       "dev": true,
       "requires": {
         "loud-rejection": "^1.6.0",
@@ -18655,15 +18712,16 @@
       }
     },
     "webpack-isomorphic-dev-middleware": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/webpack-isomorphic-dev-middleware/-/webpack-isomorphic-dev-middleware-4.0.2.tgz",
-      "integrity": "sha512-zzHHI2Qzrvy/vUriVWMPmRruDgT8spBCt8eMQE5kqVrw28OwfYgjpFZ3HUlSYjlG8gCBZbgjHmfG0MStg6NsVg==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/webpack-isomorphic-dev-middleware/-/webpack-isomorphic-dev-middleware-4.0.3.tgz",
+      "integrity": "sha512-jxgz35+KGAM+FWOuTnbwvyBucaDzOAufbicYMBfVILQ5RvzfUr6Z4JG4Uft816C9sVZDAagfT4mZJMePdhaH0Q==",
       "dev": true,
       "requires": {
         "anser": "^1.3.0",
         "chalk": "^2.0.0",
         "compose-middleware": "^4.0.0",
         "lodash.merge": "^4.6.0",
+        "lodash.omitby": "^4.6.0",
         "memory-fs": "^0.4.1",
         "mkdirp": "^0.5.1",
         "p-props": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
     "webpack-hot-middleware": "^2.21.2",
     "webpack-isomorphic-compiler": "^3.1.1",
     "webpack-isomorphic-compiler-reporter": "^1.3.3",
-    "webpack-isomorphic-dev-middleware": "^4.0.2",
+    "webpack-isomorphic-dev-middleware": "^4.0.3",
     "webpack-sort-chunks": "^0.1.0",
     "yn": "^2.0.0"
   },

--- a/scripts/middlewares/render.js
+++ b/scripts/middlewares/render.js
@@ -5,11 +5,13 @@ const wrap = require('lodash/wrap');
 
 function render() {
     return compose([
-        // Disable browser caching unless a specific page defined a cache-control policy
+        // If there's no `Cache-Control` header, assume that the content is private and must be revalidated
+        // This allow cached responses to be used if validation, such as ETag, is successful
+        // We shouldn't use `no-cache` because some browsers treat it as `no-store`, which forces no cache at all
         (req, res, next) => {
             res.writeHead = wrap(res.writeHead, (writeHeaders, ...args) => {
                 if (!res.get('Cache-control')) {
-                    res.set('Cache-Control', 'no-store, no-cache, must-revalidate, proxy-revalidate, max-age=0');
+                    res.set('Cache-Control', 'private, max-age=0, must-revalidate');
                 }
 
                 writeHeaders.apply(res, args);

--- a/scripts/start.js
+++ b/scripts/start.js
@@ -86,11 +86,14 @@ async function runServer(data) {
     const app = express();
 
     // Configure express app
-    app.set('etag', false); // Not necessary by default
     app.set('x-powered-by', false); // Remove x-powered-by header
 
-    // Public files in the build dir are hashed
-    // Therefore it's safe to cache them indefinitely
+    // Setup compression of responses
+    compress && app.use(compression());
+
+    // Serve files fom the build dir
+    // These files are hashed, therefore it's safe to cache them indefinitely
+    // Note that we use `express-static-gzip` to serve pre-compressed files!
     app.use(buildUrlPath, gzipStatic(buildDir, {
         maxAge: 31557600000, // 1 year
         immutable: true, // No conditional requests
@@ -100,9 +103,7 @@ async function runServer(data) {
         enableBrotli: true, // Add suport for brotli compressed files
     }));
 
-    compress && app.use('/', compression());
-
-    // The rest of the public files are served using a more modest approach using etags
+    // Serve files fom the public dir
     app.use(express.static(publicDir, {
         index: false,
     }));

--- a/scripts/util/constants.js
+++ b/scripts/util/constants.js
@@ -7,7 +7,7 @@ const srcDir = path.join(projectDir, 'src');
 const publicDir = path.join(projectDir, 'public');
 // `buildDir` must be a sulfolder of `publicDir` and must not contain any unsafe URL char
 // in its name, such as # or ?
-const buildDir = path.join(publicDir, 'build');
+const buildDir = path.join(publicDir, '_build');
 
 module.exports = {
     projectDir,


### PR DESCRIPTION
- Enable etag in both dev and prod server
- Tweak default Cache-Control value to use validation (etag)
- Upgrade webpack-isomorphic-dev-middleware which also caches responses
- Make fallthrough consistent in both dev and prod server
- Change build directory to _build so that it doesn't conflict with any /build/* routes

This PR may only be merged after #96 is merged because it was built upon it.