### PR TITLE
feat: compile all node_modules

### DIFF
--- a/scripts/config/webpack/config-client.js
+++ b/scripts/config/webpack/config-client.js
@@ -75,7 +75,6 @@ module.exports = ({ minify } = {}) => {
                 // Babel loader enables us to use new ECMA features + react's JSX
                 {
                     test: /\.js$/,
-                    exclude: /node_modules/,
                     use: [
                         {
                             loader: require.resolve('babel-loader'),

--- a/scripts/config/webpack/config-server.js
+++ b/scripts/config/webpack/config-server.js
@@ -60,7 +60,6 @@ module.exports = ({ minify } = {}) => {
                 // Babel loader enables us to use new ECMA features + react's JSX
                 {
                     test: /\.js$/,
-                    exclude: /node_modules/,
                     use: [
                         {
                             loader: require.resolve('babel-loader'),
@@ -76,8 +75,6 @@ module.exports = ({ minify } = {}) => {
                                 plugins: [
                                     // Necessary for import() to work
                                     require.resolve('babel-plugin-dynamic-import-node'),
-                                    // <3 hot module reload
-                                    isDev ? require.resolve('react-hot-loader/babel') : null,
                                 ]
                                 .filter((plugin) => plugin),
                             },


### PR DESCRIPTION
The future is to run babel through every code, including node_modules:
- Many authors are publishing uncompiled code into npm
- It doesn't make sense to compile at the lib level because we don't know in which context it will be used. For instance, we might compile a library down to ES5 but it might be used in app that only targets green browsers, making the bundle unnecessary larger (or vice-versa).

You may read more here: https://github.com/parcel-bundler/parcel/pull/559#discussion_r161926651

The `babel-loader` has a very good cache for sometime now, making compiling everything really fast.
`create-react-app` will be compiling everything in their next major version too.

Here are some benchmarks:

**Compile just `src/`:**
- Cold cache: ~4.6sec
- Cached: ~3.8sec
- HMR: ~0.4sec

**Compile everything:**
- Cold cache: ~15.2sec
- Cached: ~4.7sec
- HMR: ~0.4sec

**Compile everything + `thread-loader`:**
- Cold cache: ~11.8sec
- Cached: ~4.7sec
- HMR: ~1.4sec


Based on these results, I've chosen to go without `thread-loader` because HMR becomes much slower.