### PR TITLE
fix(dependency): remove ie11 work-around in helmet

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "prop-types": "^15.5.8",
     "react": "^16.4.2",
     "react-dom": "^16.4.2",
-    "react-helmet": "^5.0.0",
+    "react-helmet": "^5.2.0",
     "react-router": "^3.2.0",
     "react-router-scroll": "^0.4.1",
     "serialize-javascript": "^1.4.0",

--- a/src/App.js
+++ b/src/App.js
@@ -6,10 +6,6 @@ import Footer from './footer/Footer';
 import styles from './App.css';
 import buildPageRoutes from './pages/buildRoutes';
 
-// Force Helmet's defer prop to false until it works out a bug on IE11
-// See: https://github.com/nfl/react-helmet/issues/336
-Helmet.defaultProps.defer = false;
-
 class App extends PureComponent {
         static propTypes = {
             children: PropTypes.element,


### PR DESCRIPTION
This PR fixes an old workaround to make react-helmet work with internet explorer v11.

See https://github.com/nfl/react-helmet/issues/336 and https://github.com/dcsaszar/react-helmet/commit/913640e69bf1535993abfa73a813942cc48909cd for more info.

This change is only available from 5.2.0 onwards.